### PR TITLE
README: remove contributing instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [go4.org](http://go4.org) is a collection of packages for
 Go programmers.
 
-They started out living in [Camlistore](https://camlistore.org)'s repo
-and elsewhere but they have nothing to do with Camlistore, so we're
+They started out living in [Perkeep](https://perkeep.org)'s repo
+and elsewhere but they have nothing to do with Perkeep, so we're
 moving them here.
 
 ## Details
@@ -49,40 +49,9 @@ moving them here.
     place to help run the tests on different OS/arches. For now we
     have Travis at least.
 
-## Contributing
+## Contact
 
-To add code to go4, send a pull request or push a change to Gerrithub.
-
-We assume you already have your $GOPATH set and the go4 code cloned at
-$GOPATH/src/go4.org. For example:
-
-* `git clone https://review.gerrithub.io/camlistore/go4 $GOPATH/src/go4.org`
-
-### To push a code review to Gerrithub directly:
-
-* Sign in to [http://gerrithub.io](http://gerrithub.io "Gerrithub") with your Github account.
-
-* Install the git hook that adds the magic "Change-Id" line to your commit messages:
-
-  `curl "https://camlistore.googlesource.com/camlistore/+/master/misc/commit-msg.githook?format=TEXT" | base64 -d > $GOPATH/src/go4.org/.git/hooks/commit-msg`
-
-* make changes
-
-* commit (the unit of code review is a single commit identified by the Change-ID, **NOT** a series of commits on a branch)
-
-* `git push ssh://$YOUR_GITHUB_USERNAME@review.gerrithub.io:29418/camlistore/go4 HEAD:refs/for/master`
-
-### Using Github Pull Requests
-
-* send a pull request with a single commit
-
-* create a Gerrithub code review at https://review.gerrithub.io/plugins/github-plugin/static/pullrequests.html, selecting the pull request you just created.
-
-### Problems contributing?
-
-* Please file an issue or contact the [Camlistore mailing list](https://groups.google.com/forum/#!forum/camlistore) for any problems with the above.
-
-See [https://review.gerrithub.io/Documentation/user-upload.html](https://review.gerrithub.io/Documentation/user-upload.html) for more generic documentation.
-
-(TODO: more docs on Gerrit, integrate git-codereview, etc.)
+For any question, or communication when a Github issue is not appropriate,
+please contact the [Perkeep mailing
+list](https://groups.google.com/forum/#!forum/perkeep).
 


### PR DESCRIPTION
As we want to try accepting Github PRs now.

Also update the point of contact to the Perkeep mailing-list.