### PR TITLE
travis CI: update cloud.google.com/go/storage dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 go_import_path: go4.org
 language: go
 go:
-  - 1.7
+  - 1.10
   - tip
 before_install:
   - go get -u cloud.google.com/go/storage
   - cd $HOME/gopath/src/cloud.google.com/go
-  - git reset --hard 5aca3b7200b228d4b47e9e511f1d77ac270855ff
+  - git reset --hard 4d445121f7d55f37b70187e796b16e64f6eea7a0
   - cd $HOME/gopath/src/go4.org


### PR DESCRIPTION
Because I've noticed builds in Travis were failing because of it.

And switch to Go 1.10 while we're at it.