### PR TITLE
Travis CI: quote Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 go_import_path: go4.org
 language: go
 go:
-  - 1.10
+  - "1.10"
   - tip
 before_install:
   - go get -u cloud.google.com/go/storage


### PR DESCRIPTION
Otherwise it's parsed as Go 1.1, as reported in:
https://github.com/travis-ci/travis-ci/issues/9247