### PR TITLE
Add Go import comments.

### DIFF
--- a/reflectutil/reflectutil.go
+++ b/reflectutil/reflectutil.go
@@ -3,7 +3,7 @@
 // license that can be found in the LICENSE file.
 
 // Package reflectutil contains reflect utilities.
-package reflectutil
+package reflectutil // import "go4.org/reflectutil"
 
 import "reflect"
 

--- a/sort/sort.go
+++ b/sort/sort.go
@@ -19,7 +19,7 @@
 // Per Go's "no +1 policy", please only leave a comment on that issue
 // if you have something unique to add. Use Github's emoji reactions
 // otherwise.
-package sort
+package sort // import "go4.org/sort"
 
 import (
 	"reflect"

--- a/testing/functest/functest.go
+++ b/testing/functest/functest.go
@@ -68,7 +68,7 @@ limitations under the License.
 //	functest.go:304: three: square(3) = 9; want 999
 //	FAIL
 //
-package functest
+package functest // import "go4.org/testing/functest"
 
 import (
 	"bytes"


### PR DESCRIPTION
This pull request was made with an automated tool.

The suggested change adds an import comment to a file in each package
to ensure that the package is always imported using its canonical
import path. With this comment in place, the go tool guarantees
that the package can be imported only from this path.

For more information, see https://golang.org/s/go14customimport,
in particular the "Proposal" section.
