### PR TITLE
README: update Travis badge to go4org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # go4
 
-[![travis badge](https://travis-ci.org/camlistore/go4.svg?branch=master)](https://travis-ci.org/camlistore/go4 "Travis CI")
+[![travis badge](https://travis-ci.org/go4org/go4.svg?branch=master)](https://travis-ci.org/go4org/go4 "Travis CI")
 
 [go4.org](http://go4.org) is a collection of packages for
 Go programmers.


### PR DESCRIPTION
The go4 repository has moved from camlistore/go4 to go4org/go4.
This change updates the Travis badge URLs to match.