### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/readerutil/readerutil.go
+++ b/readerutil/readerutil.go
@@ -50,7 +50,7 @@ type varStatReader struct {
 	r io.Reader
 }
 
-// NewReaderStats returns an io.Reader that will have the number of bytes
+// NewStatsReader returns an io.Reader that will have the number of bytes
 // read from r added to v.
 func NewStatsReader(v *expvar.Int, r io.Reader) io.Reader {
 	return &varStatReader{v, r}
@@ -67,7 +67,7 @@ type varStatReadSeeker struct {
 	rs io.ReadSeeker
 }
 
-// NewReaderStats returns an io.ReadSeeker that will have the number of bytes
+// NewStatsReadSeeker returns an io.ReadSeeker that will have the number of bytes
 // read from rs added to v.
 func NewStatsReadSeeker(v *expvar.Int, rs io.ReadSeeker) io.ReadSeeker {
 	return &varStatReadSeeker{v, rs}

--- a/types/types.go
+++ b/types/types.go
@@ -107,7 +107,7 @@ func (t Time3339) Time() time.Time {
 	return time.Time(t)
 }
 
-// IsZero returns whether the time is Go zero or Unix zero.
+// IsAnyZero returns whether the time is Go zero or Unix zero.
 func (t *Time3339) IsAnyZero() bool {
 	return t == nil || time.Time(*t).IsZero() || time.Time(*t).Unix() == 0
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from Effective Go. It’s admittedly a relatively minor fix up. Does this help you?