### PR TITLE
strutil: return the condition instead of returning based on condition

### DIFF
--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -54,9 +54,10 @@ func genSplit(dst []string, s, sep string, sepSave, n int) []string {
 // AppendSplitN is like strings.SplitN but appends to and returns dst.
 // Unlike strings.SplitN, an empty separator is not supported.
 // The count n determines the number of substrings to return:
-//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
-//   n == 0: the result is nil (zero substrings)
-//   n < 0: all substrings
+//
+//	n > 0: at most n substrings; the last substring will be the unsplit remainder.
+//	n == 0: the result is nil (zero substrings)
+//	n < 0: all substrings
 func AppendSplitN(dst []string, s, sep string, n int) []string {
 	return genSplit(dst, s, sep, 0, n)
 }
@@ -75,10 +76,7 @@ func equalFoldRune(sr, tr rune) bool {
 	// Fast check for ASCII.
 	if tr < utf8.RuneSelf && 'A' <= sr && sr <= 'Z' {
 		// ASCII, and sr is upper case.  tr must be lower case.
-		if tr == sr+'a'-'A' {
-			return true
-		}
-		return false
+		return tr == sr+'a'-'A'
 	}
 
 	// General case.  SimpleFold(x) returns the next equivalent rune > x
@@ -87,10 +85,7 @@ func equalFoldRune(sr, tr rune) bool {
 	for r != sr && r < tr {
 		r = unicode.SimpleFold(r)
 	}
-	if r == tr {
-		return true
-	}
-	return false
+	return r == tr
 }
 
 // HasPrefixFold is like strings.HasPrefix but uses Unicode case-folding,

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -228,3 +228,21 @@ func BenchmarkHasPrefixFold(tb *testing.B) {
 		}
 	}
 }
+
+func BenchmarkContainsFoldToLower(tb *testing.B) {
+	a, b := "kamlistore", "AMLI"
+	for i := 0; i < tb.N; i++ {
+		if !strings.Contains(strings.ToLower(a), strings.ToLower(b)) {
+			tb.Fatalf("%q should have the substring %q", a, b)
+		}
+	}
+}
+
+func BenchmarkContainsFold(tb *testing.B) {
+	a, b := "kamlistore", "AMLI"
+	for i := 0; i < tb.N; i++ {
+		if !ContainsFold(a, b) {
+			tb.Fatalf("%q should have the substring %q", a, b)
+		}
+	}
+}


### PR DESCRIPTION
Quick change where we return the condition of the if statement instead of checking then returning true or false.

NOTE: Added extra benchmark and fixed a lint 
```
name              old time/op    new time/op    delta
HasSuffixFold-10    26.6ns ± 1%    26.2ns ± 1%  -1.22%  (p=0.000 n=10+10)
HasPrefixFold-10    22.3ns ± 1%    21.7ns ± 0%  -2.45%  (p=0.000 n=8+8)
ContainsFold-10     21.1ns ± 0%    20.4ns ± 0%  -3.03%  (p=0.000 n=9+10)

name              old alloc/op   new alloc/op   delta
HasSuffixFold-10     0.00B          0.00B         ~     (all equal)
HasPrefixFold-10     0.00B          0.00B         ~     (all equal)
ContainsFold-10      0.00B          0.00B         ~     (all equal)

name              old allocs/op  new allocs/op  delta
HasSuffixFold-10      0.00           0.00         ~     (all equal)
HasPrefixFold-10      0.00           0.00         ~     (all equal)
ContainsFold-10       0.00           0.00         ~     (all equal)
```